### PR TITLE
fix: support evm chains

### DIFF
--- a/relayer/provider/cosmos/tx.go
+++ b/relayer/provider/cosmos/tx.go
@@ -1797,11 +1797,10 @@ EventLoop:
 		default:
 			rcvPackets = append(rcvPackets, rp)
 		}
-	}
-
-	// If there is a relayPacket, return it
-	if len(rcvPackets) > 0 || len(timeoutPackets) > 0 {
-		return rcvPackets, timeoutPackets, nil
+		// If there is a relayPacket, return it
+		if len(rcvPackets) > 0 || len(timeoutPackets) > 0 {
+			return rcvPackets, timeoutPackets, nil
+		}
 	}
 
 	return nil, nil, fmt.Errorf("no packet data found")


### PR DESCRIPTION
This pr adds the following:
1. handling duplicate packet events generated by evm rollapps
2. Adding batching to `tx relay-packets` for greater stability 